### PR TITLE
RHTAPBUGS-318: Fetch tag in RHTAP build

### DIFF
--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -30,6 +30,15 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepOverrides:
+        - name: build
+          resources:
+            requests:
+              memory: 6Gi
+            limits:
+              memory: 6Gi
   pipelineSpec:
     finally:
     - name: show-sbom
@@ -144,7 +153,7 @@ spec:
       - name: revision
         value: $(params.revision)
       - name: depth
-        value: "0"
+        value: "100"
       - name: refspec
         value: "refs/tags/*:refs/tags/* refs/heads/{{source_branch}}"
       runAfter:

--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -143,6 +143,10 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
+      - name: depth
+        value: "0"
+      - name: refspec
+        value: "refs/tags/*:refs/tags/* refs/heads/{{source_branch}}"
       runAfter:
       - init
       taskRef:

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -140,6 +140,10 @@ spec:
         value: $(params.git-url)
       - name: revision
         value: $(params.revision)
+      - name: depth
+        value: "0"
+      - name: refspec
+        value: "refs/tags/*:refs/tags/* refs/heads/{{source_branch}}"
       runAfter:
       - init
       taskRef:

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -27,6 +27,15 @@ spec:
     value: .
   - name: revision
     value: '{{revision}}'
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepOverrides:
+        - name: build
+          resources:
+            requests:
+              memory: 6Gi
+            limits:
+              memory: 6Gi
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
The build process requires tags to be presented (it runs git describe). Configure the pipeline to fetch the recent 100 commits and all the tags.